### PR TITLE
Return user friendly error message in error

### DIFF
--- a/skygear/src/androidTest/java/io/skygear/skygear/AssetPostRequestUnitTest.java
+++ b/skygear/src/androidTest/java/io/skygear/skygear/AssetPostRequestUnitTest.java
@@ -189,7 +189,7 @@ public class AssetPostRequestUnitTest {
                 assertEquals(assetToUpload.getSize(), asset.getSize());
                 assertEquals(assetToUpload.data, asset.data);
 
-                assertEquals("Test Error", error.getMessage());
+                assertEquals("Test Error", error.getDetailMessage());
 
                 checkpoints[0] = true;
             }

--- a/skygear/src/androidTest/java/io/skygear/skygear/AssetPreparePostResponseHandlerUnitTest.java
+++ b/skygear/src/androidTest/java/io/skygear/skygear/AssetPreparePostResponseHandlerUnitTest.java
@@ -149,7 +149,7 @@ public class AssetPreparePostResponseHandlerUnitTest {
 
             @Override
             public void onPreparePostFail(Error error) {
-                assertEquals("Test Error", error.getMessage());
+                assertEquals("Test Error", error.getDetailMessage());
                 checkpoints[0] = true;
             }
         };

--- a/skygear/src/androidTest/java/io/skygear/skygear/AuthResponseHandlerUnitTest.java
+++ b/skygear/src/androidTest/java/io/skygear/skygear/AuthResponseHandlerUnitTest.java
@@ -62,7 +62,7 @@ public class AuthResponseHandlerUnitTest {
 
             @Override
             public void onAuthFail(Error error) {
-                assertEquals("Test error", error.getMessage());
+                assertEquals("Test error", error.getDetailMessage());
                 checkpoints[0] = true;
             }
         };

--- a/skygear/src/androidTest/java/io/skygear/skygear/AuthResponseHandlerWrapperUnitTest.java
+++ b/skygear/src/androidTest/java/io/skygear/skygear/AuthResponseHandlerWrapperUnitTest.java
@@ -56,7 +56,7 @@ public class AuthResponseHandlerWrapperUnitTest {
             @Override
             public void onAuthFail(Error error) {
                 checkpoints[0] = true;
-                assertEquals("Test Error", error.getMessage());
+                assertEquals("Test Error", error.getDetailMessage());
             }
         };
 

--- a/skygear/src/androidTest/java/io/skygear/skygear/LambdaResponseHandlerUnitTest.java
+++ b/skygear/src/androidTest/java/io/skygear/skygear/LambdaResponseHandlerUnitTest.java
@@ -49,7 +49,7 @@ public class LambdaResponseHandlerUnitTest {
 
             @Override
             public void onLambdaFail(Error error) {
-                assertEquals("Test Error", error.getMessage());
+                assertEquals("Test Error", error.getDetailMessage());
                 checkpoints[0] = true;
             }
         };

--- a/skygear/src/androidTest/java/io/skygear/skygear/LogoutResponseHandlerUnitTest.java
+++ b/skygear/src/androidTest/java/io/skygear/skygear/LogoutResponseHandlerUnitTest.java
@@ -42,7 +42,7 @@ public class LogoutResponseHandlerUnitTest {
 
             @Override
             public void onLogoutFail(Error error) {
-                assertEquals("Test Error", error.getMessage());
+                assertEquals("Test Error", error.getDetailMessage());
             }
         };
 

--- a/skygear/src/androidTest/java/io/skygear/skygear/LogoutResponseHandlerWrapperUnitTest.java
+++ b/skygear/src/androidTest/java/io/skygear/skygear/LogoutResponseHandlerWrapperUnitTest.java
@@ -50,7 +50,7 @@ public class LogoutResponseHandlerWrapperUnitTest {
             @Override
             public void onLogoutFail(Error error) {
                 checkpoints[0] = true;
-                assertEquals("Test Error", error.getMessage());
+                assertEquals("Test Error", error.getDetailMessage());
             }
         };
 

--- a/skygear/src/androidTest/java/io/skygear/skygear/RecordDeleteResponseHandlerUnitTest.java
+++ b/skygear/src/androidTest/java/io/skygear/skygear/RecordDeleteResponseHandlerUnitTest.java
@@ -91,7 +91,7 @@ public class RecordDeleteResponseHandlerUnitTest {
 
                 assertEquals("48092492-0791-4120-B314-022202AD3970", ids[0]);
                 assertEquals(Error.Code.RESOURCE_NOT_FOUND, errors.get("48092492-0791-4120-B314-022202AD3971").getCode());
-                assertEquals("record not found", errors.get("48092492-0791-4120-B314-022202AD3971").getMessage());
+                assertEquals("record not found", errors.get("48092492-0791-4120-B314-022202AD3971").getDetailMessage());
 
                 checkpoints[0] = true;
             }
@@ -144,7 +144,7 @@ public class RecordDeleteResponseHandlerUnitTest {
             @Override
             public void onDeleteFail(Error error) {
                 assertEquals(Error.Code.PERMISSION_DENIED, error.getCode());
-                assertEquals("no permission to delete", error.getMessage());
+                assertEquals("no permission to delete", error.getDetailMessage());
                 checkpoints[0] = true;
             }
         };
@@ -169,7 +169,7 @@ public class RecordDeleteResponseHandlerUnitTest {
 
             @Override
             public void onDeleteFail(Error error) {
-                assertEquals("Unknown server error", error.getMessage());
+                assertEquals("Unknown server error", error.getDetailMessage());
                 checkpoints[0] = true;
             }
         };

--- a/skygear/src/androidTest/java/io/skygear/skygear/RecordQueryResponseHandlerUnitTest.java
+++ b/skygear/src/androidTest/java/io/skygear/skygear/RecordQueryResponseHandlerUnitTest.java
@@ -117,7 +117,7 @@ public class RecordQueryResponseHandlerUnitTest {
 
             @Override
             public void onQueryError(Error error) {
-                assertEquals("Test error", error.getMessage());
+                assertEquals("Test error", error.getDetailMessage());
                 checkpoints[0] = true;
             }
         };

--- a/skygear/src/androidTest/java/io/skygear/skygear/RecordSaveResponseHandlerUnitTest.java
+++ b/skygear/src/androidTest/java/io/skygear/skygear/RecordSaveResponseHandlerUnitTest.java
@@ -173,7 +173,7 @@ public class RecordSaveResponseHandlerUnitTest {
                 assertEquals(12.345, record1.get("abc"));
 
                 Error.Code code2 = errors.get("48092492-0791-4120-B314-022202AD3971").getCode();
-                String reason2 = errors.get("48092492-0791-4120-B314-022202AD3971").getMessage();
+                String reason2 = errors.get("48092492-0791-4120-B314-022202AD3971").getDetailMessage();
                 assertEquals(Error.Code.UNEXPECTED_ERROR, code2);
                 assertEquals("pq: duplicate key value violates unique constraint \"note__id_key\"", reason2);
 
@@ -228,7 +228,7 @@ public class RecordSaveResponseHandlerUnitTest {
             @Override
             public void onSaveFail(Error error) {
                 assertEquals(Error.Code.UNEXPECTED_ERROR, error.getCode());
-                assertEquals("pq: duplicate key value violates unique constraint \"note__id_key\"", error.getMessage());
+                assertEquals("pq: duplicate key value violates unique constraint \"note__id_key\"", error.getDetailMessage());
                 checkpoints[0] = true;
             }
         };
@@ -253,7 +253,7 @@ public class RecordSaveResponseHandlerUnitTest {
 
             @Override
             public void onSaveFail(Error error) {
-                assertEquals("Unknown server error", error.getMessage());
+                assertEquals("Unknown server error", error.getDetailMessage());
                 checkpoints[0] = true;
             }
         };

--- a/skygear/src/androidTest/java/io/skygear/skygear/RegisterDeviceResponseHandlerUnitTest.java
+++ b/skygear/src/androidTest/java/io/skygear/skygear/RegisterDeviceResponseHandlerUnitTest.java
@@ -44,7 +44,7 @@ public class RegisterDeviceResponseHandlerUnitTest {
 
             @Override
             public void onRegisterError(Error error) {
-                assertEquals("Test error", error.getMessage());
+                assertEquals("Test error", error.getDetailMessage());
                 checkpoints[0] = true;
             }
         };

--- a/skygear/src/androidTest/java/io/skygear/skygear/RequestManagerUnitTest.java
+++ b/skygear/src/androidTest/java/io/skygear/skygear/RequestManagerUnitTest.java
@@ -290,7 +290,8 @@ public class RequestManagerUnitTest {
                                     "  \"error\": {" +
                                     "    \"name\": \"PermissionDenied\", " +
                                     "    \"code\": 102," +
-                                    "    \"message\": \"write is not allowed\"" +
+                                    "    \"message\": \"write is not allowed\"," +
+                                    "    \"info\": {\"foo\":\"bar\"}" +
                                     "  }" +
                                     "}"
                             )
@@ -316,7 +317,14 @@ public class RequestManagerUnitTest {
 
             @Override
             public void onFail(Error error) {
-                assertEquals("write is not allowed", error.getMessage());
+                assertEquals("write is not allowed", error.getDetailMessage());
+                assertEquals("PermissionDenied", error.getName());
+                assertEquals(Error.Code.PERMISSION_DENIED, error.getCode());
+                try {
+                    assertEquals("bar", error.getInfo().getString("foo"));
+                } catch (JSONException e) {
+                    fail(e.getMessage());
+                }
                 checkpoints[0] = true;
                 latch.countDown();
             }
@@ -398,7 +406,7 @@ public class RequestManagerUnitTest {
 
             @Override
             public void onFail(Error error) {
-                assertEquals("Test validation exception", error.getMessage());
+                assertEquals("Test validation exception", error.getDetailMessage());
 
                 checkpoints[0] = true;
                 latch.countDown();

--- a/skygear/src/androidTest/java/io/skygear/skygear/SetRoleResponseHandlerUnitTest.java
+++ b/skygear/src/androidTest/java/io/skygear/skygear/SetRoleResponseHandlerUnitTest.java
@@ -54,7 +54,7 @@ public class SetRoleResponseHandlerUnitTest {
 
             @Override
             public void onSetFail(Error error) {
-                assertEquals("Test Error", error.getMessage());
+                assertEquals("Test Error", error.getDetailMessage());
                 checkpoints[0] = true;
             }
         };

--- a/skygear/src/androidTest/java/io/skygear/skygear/UnregisterDeviceResponseHandlerUnitTest.java
+++ b/skygear/src/androidTest/java/io/skygear/skygear/UnregisterDeviceResponseHandlerUnitTest.java
@@ -44,7 +44,7 @@ public class UnregisterDeviceResponseHandlerUnitTest {
 
             @Override
             public void onUnregisterError(Error error) {
-                assertEquals("Test error", error.getMessage());
+                assertEquals("Test error", error.getDetailMessage());
                 checkpoints[0] = true;
             }
         };

--- a/skygear/src/androidTest/java/io/skygear/skygear/UserQueryResponseHandlerUnitTest.java
+++ b/skygear/src/androidTest/java/io/skygear/skygear/UserQueryResponseHandlerUnitTest.java
@@ -82,7 +82,7 @@ public class UserQueryResponseHandlerUnitTest {
 
             @Override
             public void onQueryFail(Error error) {
-                assertEquals("Test Error", error.getMessage());
+                assertEquals("Test Error", error.getDetailMessage());
                 checkpoints[0] = true;
             }
         };

--- a/skygear/src/androidTest/java/io/skygear/skygear/UserSaveResponseHandlerUnitTest.java
+++ b/skygear/src/androidTest/java/io/skygear/skygear/UserSaveResponseHandlerUnitTest.java
@@ -56,7 +56,7 @@ public class UserSaveResponseHandlerUnitTest {
 
             @Override
             public void onSaveFail(Error error) {
-                assertEquals("Test Error", error.getMessage());
+                assertEquals("Test Error", error.getDetailMessage());
                 checkpoints[0] = true;
             }
         };

--- a/skygear/src/main/java/io/skygear/skygear/Container.java
+++ b/skygear/src/main/java/io/skygear/skygear/Container.java
@@ -309,7 +309,7 @@ public final class Container implements AuthResolver {
                 public void onRegisterError(Error error) {
                     Log.w(TAG, String.format(
                             "Fail to register device token: %s",
-                            error.getMessage()
+                            error.getDetailMessage()
                     ));
                 }
             };
@@ -332,7 +332,7 @@ public final class Container implements AuthResolver {
             public void onUnregisterError(Error error) {
                 Log.w(TAG, String.format(
                         "Fail to unregister device token: %s",
-                        error.getMessage()
+                        error.getDetailMessage()
                 ));
             }
         });

--- a/skygear/src/main/java/io/skygear/skygear/Error.java
+++ b/skygear/src/main/java/io/skygear/skygear/Error.java
@@ -1,10 +1,15 @@
 package io.skygear.skygear;
 
+import org.json.JSONObject;
+
 /**
  * The Error for the response of Skygear Request.
  */
 public class Error extends Exception {
-    private final Code code;
+    private final int codeValue;
+    private final String name;
+    private final String detailMessage;
+    private final JSONObject info;
 
     /**
      * Instantiates a new Error.
@@ -16,7 +21,7 @@ public class Error extends Exception {
      * @param detailMessage the detail message
      */
     public Error(String detailMessage) {
-        this(Code.UNEXPECTED_ERROR, detailMessage);
+        this(Code.UNEXPECTED_ERROR.getValue(), null, detailMessage, null);
     }
 
     /**
@@ -30,19 +35,24 @@ public class Error extends Exception {
      * @param detailMessage the detail message
      */
     public Error(int codeValue, String detailMessage) {
-        this(Code.fromValue(codeValue), detailMessage);
+        this(codeValue, null, detailMessage, null);
     }
 
     /**
      * Instantiates a new Error.
      *
-     * @param code          the code
+     * @param codeValue     the code
+     * @param name          the name of the error
      * @param detailMessage the detail message
+     * @param info          the info from error message
      */
-    public Error(Code code, String detailMessage) {
-        super(detailMessage);
+    public Error(int codeValue, String name, String detailMessage, JSONObject info) {
+        super(Code.fromValue(codeValue).toString());
 
-        this.code = code;
+        this.codeValue = codeValue;
+        this.name = name;
+        this.detailMessage = detailMessage;
+        this.info = info;
     }
 
     /**
@@ -51,7 +61,7 @@ public class Error extends Exception {
      * @return the code
      */
     public Code getCode() {
-        return code;
+        return Code.fromValue(this.codeValue);
     }
 
     /**
@@ -179,5 +189,64 @@ public class Error extends Exception {
 
             return Code.UNEXPECTED_ERROR;
         }
+
+        @Override
+        public String toString() {
+            switch (this) {
+                case NOT_AUTHENTICATED:
+                    return "You have to be authenticated to perform this operation.";
+                case PERMISSION_DENIED:
+                case ACCESS_KEY_NOT_ACCEPTED:
+                case ACCESS_TOKEN_NOT_ACCEPTED:
+                    return "You are not allowed to perform this operation.";
+                case INVALID_CREDENTIALS:
+                    return "You are not allowed to log in because the credentials you provided are not valid.";
+                case INVALID_SIGNATURE:
+                case BAD_REQUEST:
+                    return "The server is unable to process the request.";
+                case INVALID_ARGUMENT:
+                    return "The server is unable to process the data.";
+                case DUPLICATED:
+                    return "This request contains duplicate of an existing resource on the server.";
+                case RESOURCE_NOT_FOUND:
+                    return "The requested resource is not found.";
+                case NOT_SUPPORTED:
+                    return "This operation is not supported.";
+                case NOT_IMPLEMENTED:
+                    return "This operation is not implemented.";
+                case CONSTRAINT_VIOLATED:
+                case INCOMPATIBLE_SCHEMA:
+                case ATOMIC_OPERATION_FAILURE:
+                case PARTIAL_OPERATION_FAILURE:
+                    return "A problem occurred while processing this request.";
+                case UNDEFINED_OPERATION:
+                    return "The requested operation is not available.";
+                case PLUGIN_INITIALIZING:
+                case PLUGIN_UNAVAILABLE:
+                    return "The server is not ready yet.";
+                case PLUGIN_TIMEOUT:
+                    return "The server took too long to process.";
+                case RECORD_QUERY_INVALID:
+                    return "A problem occurred while processing this request.";
+                case UNEXPECTED_ERROR:
+                    return "An unexpected error has occurred.";
+            }
+            return super.toString();
+        }
+    }
+
+    public String getName () {
+        return this.name;
+    }
+    public int getCodeValue() {
+        return this.codeValue;
+    }
+
+    public String getDetailMessage() {
+        return this.detailMessage;
+    }
+
+    public JSONObject getInfo() {
+        return this.info;
     }
 }

--- a/skygear/src/main/java/io/skygear/skygear/Request.java
+++ b/skygear/src/main/java/io/skygear/skygear/Request.java
@@ -104,8 +104,10 @@ public class Request implements Response.Listener<JSONObject>, Response.ErrorLis
                     JSONObject errorObject = new JSONObject(networkErrorString).getJSONObject("error");
                     String errorString = errorObject.getString("message");
                     int errorCodeValue = errorObject.getInt("code");
+                    String errorName = errorObject.getString("name");
+                    JSONObject errorInfo = errorObject.optJSONObject("info");
 
-                    requestError = new Error(errorCodeValue, errorString);
+                    requestError = new Error(errorCodeValue, errorName, errorString, errorInfo);
                 } catch (JSONException e) {
                     requestError = new Error(networkErrorString);
                 }


### PR DESCRIPTION
connect https://github.com/SkygearIO/skygear-SDK-Android/issues/89

This PR does not localise the error message, because I don't know how to do it in an Android library. Seems like I need to access the Context in order to get the resource file so I can access the localised string, but asking for Context in the error seems to be strange... Any one familiar with Android can help?

Update:
Localisation is going to be done in another issue