### PR TITLE
Add loginWithCustomToken

### DIFF
--- a/skygear/src/androidTest/java/io/skygear/skygear/sso/CustomTokenLoginRequestUnitTest.java
+++ b/skygear/src/androidTest/java/io/skygear/skygear/sso/CustomTokenLoginRequestUnitTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 Oursky Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.skygear.skygear.sso;
+
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.security.InvalidParameterException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static junit.framework.Assert.assertEquals;
+
+@RunWith(AndroidJUnit4.class)
+public class CustomTokenLoginRequestUnitTest {
+    @Test
+    public void testCustomTokenLoginRequestFlow() throws Exception {
+        String tokenString = "eyXXXX";
+
+        CustomTokenLoginRequest req = new CustomTokenLoginRequest("eyXXXX");
+        Map<String, Object> data = req.data;
+
+        assertEquals("sso:custom_token:login", req.action);
+        assertEquals("eyXXXX", data.get("token"));
+    }
+
+    @Test(expected = InvalidParameterException.class)
+    public void testCustomTokenLoginRequestInvalidateTokenNull() throws Exception {
+        CustomTokenLoginRequest req = new CustomTokenLoginRequest(null);
+        req.validate();
+    }
+}

--- a/skygear/src/androidTest/java/io/skygear/skygear/sso/CustomTokenLoginRequestUnitTest.java
+++ b/skygear/src/androidTest/java/io/skygear/skygear/sso/CustomTokenLoginRequestUnitTest.java
@@ -35,7 +35,7 @@ public class CustomTokenLoginRequestUnitTest {
         String tokenString = "eyXXXX";
 
         CustomTokenLoginRequest req = new CustomTokenLoginRequest("eyXXXX");
-        Map<String, Object> data = req.data;
+        Map<String, Object> data = req.getData();
 
         assertEquals("sso:custom_token:login", req.action);
         assertEquals("eyXXXX", data.get("token"));

--- a/skygear/src/main/java/io/skygear/skygear/AuthContainer.java
+++ b/skygear/src/main/java/io/skygear/skygear/AuthContainer.java
@@ -25,6 +25,7 @@ import java.security.InvalidParameterException;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import io.skygear.skygear.sso.CustomTokenLoginRequest;
 
 /**
  * Auth Container for Skygear.
@@ -200,6 +201,23 @@ public class AuthContainer implements AuthResolver {
         authData.put("email", email);
 
         this.login(authData, password, handler);
+    }
+
+    /**
+     * Login with custom token.
+     *
+     * The custom token is typically created on an external server hosting a user
+     * database. This server generates the custom token so that the user on an
+     * external server can log in to Skygear Server.
+     *
+     * @param token    the token string
+     * @param handler  the response handler
+     */
+    public void loginWithCustomToken(String token, AuthResponseHandler handler) {
+        Request req = new CustomTokenLoginRequest(token);
+        req.responseHandler = new AuthResponseHandlerWrapper(this, handler);
+
+        this.getContainer().requestManager.sendRequest(req);
     }
 
     /**

--- a/skygear/src/main/java/io/skygear/skygear/Request.java
+++ b/skygear/src/main/java/io/skygear/skygear/Request.java
@@ -23,6 +23,7 @@ import com.android.volley.Response;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -37,7 +38,7 @@ public class Request implements Response.Listener<JSONObject>, Response.ErrorLis
     /**
      * The Data.
      */
-    public Map<String, Object> data;
+    protected Map<String, Object> data;
     /**
      * The Response handler.
      */
@@ -73,6 +74,10 @@ public class Request implements Response.Listener<JSONObject>, Response.ErrorLis
         this.action = action;
         this.data = data;
         this.responseHandler = responseHandler;
+    }
+
+    public Map<String, Object> getData() {
+        return Collections.unmodifiableMap(this.data);
     }
 
     /**

--- a/skygear/src/main/java/io/skygear/skygear/Request.java
+++ b/skygear/src/main/java/io/skygear/skygear/Request.java
@@ -37,7 +37,7 @@ public class Request implements Response.Listener<JSONObject>, Response.ErrorLis
     /**
      * The Data.
      */
-    Map<String, Object> data;
+    public Map<String, Object> data;
     /**
      * The Response handler.
      */

--- a/skygear/src/main/java/io/skygear/skygear/sso/CustomTokenLoginRequest.java
+++ b/skygear/src/main/java/io/skygear/skygear/sso/CustomTokenLoginRequest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 Oursky Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.skygear.skygear.sso;
+
+import java.security.InvalidParameterException;
+import java.util.HashMap;
+import java.util.Map;
+import io.skygear.skygear.Request;
+
+/**
+ * The Login with custom token request.
+ */
+public class CustomTokenLoginRequest extends Request {
+    /**
+     * Instantiates a new Login with custom token request.
+     *
+     * @param token the token string
+     */
+    public CustomTokenLoginRequest(String token) {
+        super("sso:custom_token:login");
+
+        this.data = new HashMap<>();
+        data.put("token", token);
+    }
+
+    @Override
+    protected void validate() throws Exception {
+        String token = (String) this.data.get("token");
+
+        if (token == null) {
+            throw new InvalidParameterException("Token should not be null");
+        }
+    }
+}

--- a/skygear_example/src/main/AndroidManifest.xml
+++ b/skygear_example/src/main/AndroidManifest.xml
@@ -51,6 +51,9 @@
             android:name=".LoginActivity"
             android:screenOrientation="portrait" />
         <activity
+            android:name=".CustomTokenLoginActivity"
+            android:screenOrientation="portrait" />
+        <activity
             android:name=".ChangePasswordActivity"
             android:screenOrientation="portrait" />
         <activity

--- a/skygear_example/src/main/java/io/skygear/skygear_example/CustomTokenLoginActivity.java
+++ b/skygear_example/src/main/java/io/skygear/skygear_example/CustomTokenLoginActivity.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2017 Oursky Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.skygear.skygear_example;
+
+import android.app.ProgressDialog;
+import android.content.DialogInterface;
+import android.support.v7.app.AlertDialog;
+import android.support.v7.app.AppCompatActivity;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.View;
+import android.widget.EditText;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.skygear.skygear.AuthResponseHandler;
+import io.skygear.skygear.Container;
+import io.skygear.skygear.Error;
+import io.skygear.skygear.Record;
+
+public class CustomTokenLoginActivity extends AppCompatActivity {
+    private static String LOG_TAG = CustomTokenLoginActivity.class.getSimpleName();
+
+    private Container skygear;
+    private EditText tokenInput;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_custom_token_login);
+
+        this.tokenInput = (EditText) findViewById(R.id.token_input);
+
+        this.skygear = Container.defaultContainer(this);
+    }
+
+    public void doLogin(View view) {
+        String token = this.tokenInput.getText().toString();
+
+        final ProgressDialog loading = new ProgressDialog(this);
+        loading.setTitle("Loading");
+        loading.setMessage("Logging in...");
+        loading.show();
+
+        final AlertDialog successDialog = new AlertDialog.Builder(this)
+                .setTitle("Login success")
+                .setMessage("")
+                .setPositiveButton("Back", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        CustomTokenLoginActivity.this.finish();
+                    }
+                })
+                .create();
+
+        final AlertDialog failDialog = new AlertDialog.Builder(this)
+                .setTitle("Login failed")
+                .setMessage("")
+                .setNeutralButton("Dismiss", null)
+                .create();
+
+        Log.i(LOG_TAG, "doLogin: Signup with token: " + token);
+
+        this.skygear.getAuth().loginWithCustomToken(token, new AuthResponseHandler() {
+            @Override
+            public void onAuthSuccess(Record user) {
+                loading.dismiss();
+                successDialog.setMessage("Success with user_id:\n" + user.getId());
+                successDialog.show();
+            }
+
+            @Override
+            public void onAuthFail(Error error) {
+                loading.dismiss();
+
+                failDialog.setMessage("Fail with reason: \n" + error.getMessage());
+                failDialog.show();
+            }
+        });
+    }
+}

--- a/skygear_example/src/main/java/io/skygear/skygear_example/MainActivity.java
+++ b/skygear_example/src/main/java/io/skygear/skygear_example/MainActivity.java
@@ -201,6 +201,10 @@ public class MainActivity extends AppCompatActivity {
         startActivity(new Intent(this, LoginActivity.class));
     }
 
+    public void doLoginWithCustomToken(View view) {
+        startActivity(new Intent(this, CustomTokenLoginActivity.class));
+    }
+
     public void goRecordCreateDelete(View view) {
         startActivity(new Intent(this, RecordCreateActivity.class));
     }

--- a/skygear_example/src/main/res/layout/activity_custom_token_login.xml
+++ b/skygear_example/src/main/res/layout/activity_custom_token_login.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2017 Oursky Ltd.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    android:orientation="vertical"
+    android:focusable="true"
+    android:focusableInTouchMode="true"
+    tools:context="io.skygear.skygear_example.CustomTokenLoginActivity">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="5dp">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/custom_token" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="5dp">
+
+        <EditText
+            android:id="@+id/token_input"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingLeft="5dp"
+            android:paddingRight="5dp"
+            android:lines="5"
+            android:maxLines="5" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="5dp"
+        android:gravity="center">
+
+        <Button
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:onClick="doLogin"
+            android:text="@string/login" />
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/skygear_example/src/main/res/layout/activity_main.xml
+++ b/skygear_example/src/main/res/layout/activity_main.xml
@@ -204,6 +204,15 @@
                 <Button
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:onClick="doLoginWithCustomToken"
+                    android:text="@string/login_custom_token"
+                    android:layout_marginLeft="1dp"
+                    android:layout_marginRight="1dp"
+                    />
+
+                <Button
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
                     android:onClick="doGetCurrentUser"
                     android:text="@string/who_am_i"
                     android:layout_marginLeft="1dp"

--- a/skygear_example/src/main/res/values/strings.xml
+++ b/skygear_example/src/main/res/values/strings.xml
@@ -75,4 +75,6 @@
     <string name="old_password">Old Password</string>
     <string name="new_password">New Password</string>
     <string name="confirm_password">Confirm Password</string>
+    <string name="login_custom_token">Login with Custom Token</string>
+    <string name="custom_token">Custom Token</string>
 </resources>


### PR DESCRIPTION
This commit add `loginWithCustomToken` to `AuthContainer` and add a `CustomTokenLoginRequest` in `sso` package.

When we have the new package, the Request object is required to expose the `data` object member. This member is now set to `public`.

I tried setting the member to `protected` but the test case in the `sso` package cannot access it. I love to hear how others will approach this and if there is a better solution I am happy to modify this PR.

connects #172