### PR TITLE
Android Studio 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Pull Requests Welcome!
 We really want to see Skygear grows and thrives in the open source community.
 If you have any fixes or suggestions, simply send us a pull request!
 
-The current project setup assume Android Studio 2.2+. Download it here:
+The current project setup assume Android Studio 3.0+. Download it here:
 https://developer.android.com/studio/index.html and start your contribution!
 
 ## Continuous Delivery


### PR DESCRIPTION
The required version for Android Studio changed to 3.0 since 436757c6522511dd802819ef60a29bec633911c9