### PR TITLE
Fix JSON parsing error of Map objects in Android API version <= 18

### DIFF
--- a/skygear/src/androidTest/java/io/skygear/skygear/LoginRequestUnitTest.java
+++ b/skygear/src/androidTest/java/io/skygear/skygear/LoginRequestUnitTest.java
@@ -19,6 +19,7 @@ package io.skygear.skygear;
 
 import android.support.test.runner.AndroidJUnit4;
 
+import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -38,7 +39,7 @@ public class LoginRequestUnitTest {
 
         LoginRequest req = new LoginRequest(authData, "123456");
         Map<String, Object> data = req.data;
-        Map<String, Object> payloadAuthData = (Map<String, Object>) data.get("auth_data");
+        JSONObject payloadAuthData = (JSONObject) data.get("auth_data");
 
         assertEquals("auth:login", req.action);
         assertEquals("user123", payloadAuthData.get("username"));

--- a/skygear/src/androidTest/java/io/skygear/skygear/SignupRequestUnitTest.java
+++ b/skygear/src/androidTest/java/io/skygear/skygear/SignupRequestUnitTest.java
@@ -46,7 +46,7 @@ public class SignupRequestUnitTest {
 
         SignupRequest req = new SignupRequest(authData, "123456", profile);
         Map<String, Object> data = req.data;
-        Map<String, Object> payloadAuthData = (Map<String, Object>) data.get("auth_data");
+        JSONObject payloadAuthData = (JSONObject) data.get("auth_data");
 
         assertEquals("auth:signup", req.action);
         assertEquals("user123", payloadAuthData.get("username"));

--- a/skygear/src/main/java/io/skygear/skygear/LoginRequest.java
+++ b/skygear/src/main/java/io/skygear/skygear/LoginRequest.java
@@ -17,6 +17,8 @@
 
 package io.skygear.skygear;
 
+import org.json.JSONObject;
+
 import java.security.InvalidParameterException;
 import java.util.HashMap;
 import java.util.Map;
@@ -36,20 +38,20 @@ public class LoginRequest extends Request {
 
         this.data = new HashMap<>();
 
-        this.data.put("auth_data", authData);
+        this.data.put("auth_data", new JSONObject(authData));
         this.data.put("password", password);
     }
 
     @Override
     protected void validate() throws Exception {
-        Map authData = (Map) this.data.get("auth_data");
+        JSONObject authData = (JSONObject) this.data.get("auth_data");
         String password = (String) this.data.get("password");
 
         if (authData == null) {
             throw new InvalidParameterException("Auth data should not be null");
         }
 
-        if (authData.isEmpty()) {
+        if (authData.length() <= 0) {
             throw new InvalidParameterException("Auth data should not be empty");
         }
 

--- a/skygear/src/main/java/io/skygear/skygear/LoginRequest.java
+++ b/skygear/src/main/java/io/skygear/skygear/LoginRequest.java
@@ -38,7 +38,7 @@ public class LoginRequest extends Request {
 
         this.data = new HashMap<>();
 
-        this.data.put("auth_data", new JSONObject(authData));
+        this.data.put("auth_data", authData != null ? new JSONObject(authData) : null);
         this.data.put("password", password);
     }
 

--- a/skygear/src/main/java/io/skygear/skygear/SignupRequest.java
+++ b/skygear/src/main/java/io/skygear/skygear/SignupRequest.java
@@ -17,6 +17,8 @@
 
 package io.skygear.skygear;
 
+import org.json.JSONObject;
+
 import java.security.InvalidParameterException;
 import java.util.HashMap;
 import java.util.Map;
@@ -40,7 +42,7 @@ public class SignupRequest extends Request {
         this.anonymous = false;
         this.data = new HashMap<>();
 
-        this.data.put("auth_data", authData);
+        this.data.put("auth_data", new JSONObject(authData));
         this.data.put("password", password);
 
         if (profile != null) {
@@ -64,14 +66,14 @@ public class SignupRequest extends Request {
             return;
         }
 
-        Map authData = (Map) this.data.get("auth_data");
+        JSONObject authData = (JSONObject) this.data.get("auth_data");
         String password = (String) this.data.get("password");
 
         if (authData == null) {
             throw new InvalidParameterException("Auth data should not be null");
         }
 
-        if (authData.isEmpty()) {
+        if (authData.length() <= 0) {
             throw new InvalidParameterException("Auth data should not be empty");
         }
 

--- a/skygear/src/main/java/io/skygear/skygear/SignupRequest.java
+++ b/skygear/src/main/java/io/skygear/skygear/SignupRequest.java
@@ -42,7 +42,7 @@ public class SignupRequest extends Request {
         this.anonymous = false;
         this.data = new HashMap<>();
 
-        this.data.put("auth_data", new JSONObject(authData));
+        this.data.put("auth_data", authData != null ? new JSONObject(authData) : null);
         this.data.put("password", password);
 
         if (profile != null) {


### PR DESCRIPTION
Fixes #220 
connects #220 

## What's changed
- Changed type of `authForm` from `Map` to `JSONObject` for correct auto parsing when creating JSONObject

## Things I have considered
- I have tried to utilize `Gson` library to do automatic conversion for the request, but turns out it messes up `JSONArray` format in other request such as `RecordQueryRequest`, so I abandon the method