### PR TITLE
Should allow `JSONObject.NULL` in lambda arguments

### DIFF
--- a/skygear/src/androidTest/java/io/skygear/skygear/LambdaRequestUnitTest.java
+++ b/skygear/src/androidTest/java/io/skygear/skygear/LambdaRequestUnitTest.java
@@ -238,4 +238,14 @@ public class LambdaRequestUnitTest {
         JSONObject value8 = (JSONObject) value3.get("key8");
         assertEquals("ok", value8.get("key9"));
     }
+
+    @Test
+    public void testLambdaRequestJSONNull() {
+        final HashMap<String, Object> map = new HashMap<String, Object>() {{
+            put("key1", JSONObject.NULL);
+        }};
+        LambdaRequest request = new LambdaRequest("test:op1", map);
+        Map<String, Object> data = request.getData();
+        assertEquals(JSONObject.NULL, data.get("key1"));
+    }
 }

--- a/skygear/src/main/java/io/skygear/skygear/LambdaRequest.java
+++ b/skygear/src/main/java/io/skygear/skygear/LambdaRequest.java
@@ -182,6 +182,10 @@ public class LambdaRequest extends Request {
             }
         }
 
+        if (arg == JSONObject.NULL) {
+            return true;
+        }
+
         return false;
     }
 }


### PR DESCRIPTION
-  isCompatibleArgument returns true if object is JSONObject.NULL

Connects #231