### PR TITLE
Encrypt current user data when storing into SharedPreferences

### DIFF
--- a/skygear/build.gradle
+++ b/skygear/build.gradle
@@ -42,7 +42,7 @@ android {
     useLibrary 'org.apache.http.legacy'
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 18
         targetSdkVersion 26
         versionCode 1
         versionName skygearVersion

--- a/skygear/src/androidTest/java/io/skygear/skygear/SecurePersistentStoreUnitTest.java
+++ b/skygear/src/androidTest/java/io/skygear/skygear/SecurePersistentStoreUnitTest.java
@@ -1,0 +1,115 @@
+package io.skygear.skygear;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertNull;
+
+@RunWith(AndroidJUnit4.class)
+@SuppressLint("CommitPrefEdits")
+public class SecurePersistentStoreUnitTest {
+    static Context instrumentationContext;
+
+    private static void clearSharedPreferences(Context context) {
+        SharedPreferences pref = context.getSharedPreferences(
+                PersistentStore.SKYGEAR_PREF_SPACE,
+                Context.MODE_PRIVATE
+        );
+        SharedPreferences.Editor edit = pref.edit();
+        edit.clear();
+        edit.commit();
+    }
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        instrumentationContext = InstrumentationRegistry.getContext().getApplicationContext();
+        clearSharedPreferences(instrumentationContext);
+    }
+
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+        clearSharedPreferences(instrumentationContext);
+        instrumentationContext = null;
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        clearSharedPreferences(instrumentationContext);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        clearSharedPreferences(instrumentationContext);
+    }
+
+    @Test
+    public void testPersistentStoreRestoreUserFromEmptyState() throws Exception {
+        SecurePersistentStore persistentStore = new SecurePersistentStore(instrumentationContext);
+        assertNull(persistentStore.currentUser);
+    }
+
+    @Test
+    public void testPersistentStoreSaveAndRestoreUser() throws Exception {
+        SecurePersistentStore persistentStore = new SecurePersistentStore(instrumentationContext);
+
+        // Save user
+        Map profile = new HashMap<>();
+        profile.put("username", "user_12345");
+        profile.put("email", "user12345@skygear.dev");
+
+        persistentStore.currentUser = new Record("user", "12345", profile);
+        persistentStore.accessToken = "token_12345";
+        persistentStore.save();
+
+        // Restore current user
+        SecurePersistentStore newPersistentStore = new SecurePersistentStore(instrumentationContext);
+        Record currentUser = newPersistentStore.currentUser;
+
+        assertEquals("user", currentUser.type);
+        assertEquals("12345", currentUser.id);
+        assertEquals("user_12345", currentUser.get("username"));
+        assertEquals("user12345@skygear.dev", currentUser.get("email"));
+
+        assertEquals("token_12345", persistentStore.accessToken);
+
+        // Current user information should be store in encrypted fields
+        SharedPreferences pref = instrumentationContext.getSharedPreferences(
+                SecurePersistentStore.SKYGEAR_PREF_SPACE,
+                Context.MODE_PRIVATE
+        );
+
+        String currentUserString = pref.getString(PersistentStore.CURRENT_USER_KEY, null);
+        String currentUserEncryptedString = pref.getString(
+                SecurePersistentStore.CURRENT_USER_ENCRYPTED_KEY, null);
+        String currentUserEncryptedKey = pref.getString(
+                SecurePersistentStore.CURRENT_USER_ENCRYPTED_KEY_KEY, null);
+        assertNull(currentUserString);
+        assertNotNull(currentUserEncryptedString);
+        assertNotNull(currentUserEncryptedKey);
+
+        String accessToken = pref.getString(PersistentStore.ACCESS_TOKEN_KEY, null);
+        String accessTokenEncrypted = pref.getString
+                (SecurePersistentStore.ACCESS_TOKEN_ENCRYPTED_KEY, null);
+        String accessTokenEncryptedKey = pref.getString(
+                SecurePersistentStore.ACCESS_TOKEN_ENCRYPTED_KEY_KEY, null);
+        assertNull(accessToken);
+        assertNotNull(accessTokenEncrypted);
+        assertNotNull(accessTokenEncryptedKey);
+    }
+}

--- a/skygear/src/main/java/io/skygear/skygear/Configuration.java
+++ b/skygear/src/main/java/io/skygear/skygear/Configuration.java
@@ -52,18 +52,27 @@ public final class Configuration {
      */
     final boolean pubsubConnectAutomatically;
 
+
+    /**
+     * Boolean indicating whether encrypt current user data saved in SharedPreferences.
+     */
+    final boolean encryptCurrentUserData;
+
+
     private Configuration(
             String endpoint,
             String apiKey,
             String gcmSenderId,
             boolean pubsubHandlerExecutionInBackground,
-            boolean pubsubConnectAutomatically
+            boolean pubsubConnectAutomatically,
+            boolean encryptCurrentUserData
     ) {
         this.endpoint = endpoint;
         this.apiKey = apiKey;
         this.gcmSenderId = gcmSenderId;
         this.pubsubHandlerExecutionInBackground = pubsubHandlerExecutionInBackground;
         this.pubsubConnectAutomatically = pubsubConnectAutomatically;
+        this.encryptCurrentUserData = encryptCurrentUserData;
     }
 
     /**
@@ -112,6 +121,15 @@ public final class Configuration {
     }
 
     /**
+     * Encrypt current user data boolean.
+     *
+     * @return the boolean
+     */
+    public boolean encryptCurrentUserData() {
+        return encryptCurrentUserData;
+    }
+
+    /**
      * Creates an instance of default configuration.
      *
      * This method is deprecated. You should create configuration by
@@ -148,6 +166,7 @@ public final class Configuration {
         private String gcmSenderId;
         private boolean pubsubHandlerExecutionInBackground;
         private boolean pubsubConnectAutomatically;
+        private boolean encryptCurrentUserData;
 
         /**
          * Creates an instance of Builder.
@@ -213,6 +232,18 @@ public final class Configuration {
         }
 
         /**
+         * Sets whether encrypt current user data saved in SharedPreferences.
+         *
+         * @param enabled the boolean indicating whether encryption Enabled
+         * automatically.
+         * @return the builder
+         */
+        public Builder encryptCurrentUserData(boolean enabled) {
+            this.encryptCurrentUserData = enabled;
+            return this;
+        }
+
+        /**
          * Build a configuration.
          *
          * @return the configuration
@@ -231,7 +262,8 @@ public final class Configuration {
                     this.apiKey,
                     this.gcmSenderId,
                     this.pubsubHandlerExecutionInBackground,
-                    this.pubsubConnectAutomatically
+                    this.pubsubConnectAutomatically,
+                    this.encryptCurrentUserData
             );
         }
     }

--- a/skygear/src/main/java/io/skygear/skygear/Container.java
+++ b/skygear/src/main/java/io/skygear/skygear/Container.java
@@ -146,9 +146,9 @@ public final class Container {
         }
 
         this.config = config;
+        this.configPersistentStore(config);
         this.requestManager.configure(config);
         this.pubsub.configure(config);
-        this.configPersistentStore(config);
     }
 
     /**

--- a/skygear/src/main/java/io/skygear/skygear/Container.java
+++ b/skygear/src/main/java/io/skygear/skygear/Container.java
@@ -61,7 +61,7 @@ public final class Container {
         this.context = context.getApplicationContext();
         this.config = config;
         this.requestManager = new RequestManager(this.context, this.config);
-        this.persistentStore = new PersistentStore(this.context);
+        this.persistentStore = new SecurePersistentStore(this.context);
 
         this.auth = new AuthContainer(this);
         this.pubsub = new PubsubContainer(this);

--- a/skygear/src/main/java/io/skygear/skygear/Container.java
+++ b/skygear/src/main/java/io/skygear/skygear/Container.java
@@ -31,7 +31,7 @@ public final class Container {
     private static final String TAG = "Skygear SDK";
     private static Container sharedInstance;
 
-    final PersistentStore persistentStore;
+    PersistentStore persistentStore;
     final Context context;
     final RequestManager requestManager;
     Configuration config;
@@ -61,18 +61,13 @@ public final class Container {
         this.context = context.getApplicationContext();
         this.config = config;
         this.requestManager = new RequestManager(this.context, this.config);
-        this.persistentStore = new SecurePersistentStore(this.context);
 
         this.auth = new AuthContainer(this);
         this.pubsub = new PubsubContainer(this);
         this.push = new PushContainer(this);
         this.publicDatabase = Database.Factory.publicDatabase(this);
         this.privateDatabase = Database.Factory.privateDatabase(this);
-        this.requestManager.accessToken = this.persistentStore.accessToken;
-
-        if (this.persistentStore.defaultAccessControl != null) {
-            AccessControl.defaultAccessControl = this.persistentStore.defaultAccessControl;
-        }
+        this.configPersistentStore(config);
     }
 
     /**
@@ -153,6 +148,7 @@ public final class Container {
         this.config = config;
         this.requestManager.configure(config);
         this.pubsub.configure(config);
+        this.configPersistentStore(config);
     }
 
     /**
@@ -262,5 +258,17 @@ public final class Container {
 
             }
         });
+    }
+
+    private void configPersistentStore(Configuration config) {
+        if (config != null && config.encryptCurrentUserData) {
+            this.persistentStore = new SecurePersistentStore(this.context);
+        } else {
+            this.persistentStore = new PersistentStore(this.context);
+        }
+        this.requestManager.accessToken = this.persistentStore.accessToken;
+        if (this.persistentStore.defaultAccessControl != null) {
+            AccessControl.defaultAccessControl = this.persistentStore.defaultAccessControl;
+        }
     }
 }

--- a/skygear/src/main/java/io/skygear/skygear/PersistentStore.java
+++ b/skygear/src/main/java/io/skygear/skygear/PersistentStore.java
@@ -109,7 +109,7 @@ class PersistentStore {
         prefEditor.apply();
     }
 
-    private void restoreAuthUser(SharedPreferences pref) {
+    void restoreAuthUser(SharedPreferences pref) {
         String currentUserString = pref.getString(CURRENT_USER_KEY, null);
 
         if (currentUserString == null) {
@@ -126,7 +126,7 @@ class PersistentStore {
         }
     }
 
-    private void saveAuthUser(SharedPreferences.Editor prefEditor) {
+    void saveAuthUser(SharedPreferences.Editor prefEditor) {
         if (this.currentUser != null) {
             prefEditor.putString(CURRENT_USER_KEY,
                     RecordSerializer.serialize(this.currentUser).toString()
@@ -136,11 +136,11 @@ class PersistentStore {
         }
     }
 
-    private void restoreAccessToken(SharedPreferences pref) {
+    void restoreAccessToken(SharedPreferences pref) {
         this.accessToken = pref.getString(ACCESS_TOKEN_KEY, null);
     }
 
-    private void saveAccessToken(SharedPreferences.Editor prefEditor) {
+    void saveAccessToken(SharedPreferences.Editor prefEditor) {
         if (this.accessToken != null) {
             prefEditor.putString(ACCESS_TOKEN_KEY, this.accessToken);
         } else {

--- a/skygear/src/main/java/io/skygear/skygear/PersistentStore.java
+++ b/skygear/src/main/java/io/skygear/skygear/PersistentStore.java
@@ -42,7 +42,7 @@ class PersistentStore {
     static final String DEVICE_ID_KEY = "device_id";
     static final String DEVICE_TOKEN_KEY = "device_token";
 
-    private final Context context;
+    final Context context;
     /**
      * The Current user.
      */

--- a/skygear/src/main/java/io/skygear/skygear/SecurePersistentStore.java
+++ b/skygear/src/main/java/io/skygear/skygear/SecurePersistentStore.java
@@ -150,14 +150,6 @@ class SecurePersistentStore extends PersistentStore {
         return decryptor;
     }
 
-    private String getRSACipherProvider() {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-            return "AndroidOpenSSL";
-        } else {
-            return "AndroidKeyStoreBCWorkaround";
-        }
-    }
-
     class Decryptor {
 
         private KeyStore keyStore;
@@ -172,7 +164,7 @@ class SecurePersistentStore extends PersistentStore {
             }
             KeyStore.PrivateKeyEntry privateKeyEntry = (KeyStore.PrivateKeyEntry)keyStore.getEntry(
                     KEY_ALIAS, null);
-            Cipher output = Cipher.getInstance(RSA_MODE, getRSACipherProvider());
+            Cipher output = Cipher.getInstance(RSA_MODE);
             output.init(Cipher.DECRYPT_MODE, privateKeyEntry.getPrivateKey());
             CipherInputStream cipherInputStream = new CipherInputStream(
                     new ByteArrayInputStream(encrypted), output);
@@ -241,7 +233,7 @@ class SecurePersistentStore extends PersistentStore {
                 InvalidKeyException, InvalidAlgorithmParameterException, CertificateException,
                 KeyStoreException, UnrecoverableEntryException {
             PublicKey publicKey = getRSAPublicKey();
-            Cipher inputCipher = Cipher.getInstance(RSA_MODE, getRSACipherProvider());
+            Cipher inputCipher = Cipher.getInstance(RSA_MODE);
             inputCipher.init(Cipher.ENCRYPT_MODE, publicKey);
 
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();

--- a/skygear/src/main/java/io/skygear/skygear/SecurePersistentStore.java
+++ b/skygear/src/main/java/io/skygear/skygear/SecurePersistentStore.java
@@ -54,7 +54,7 @@ class SecurePersistentStore extends PersistentStore {
     static final String ACCESS_TOKEN_ENCRYPTED_KEY_KEY = "access_token_encrypted_key";
 
     private static final String RSA_MODE =  "RSA/ECB/PKCS1Padding";
-    private static final String AES_MODE = "AES/ECB/PKCS7Padding";
+    private static final String AES_MODE = "AES/ECB/PKCS5Padding";
     private static final String ANDROID_KEY_STORE = "AndroidKeyStore";
 
     Encryptor encryptor;
@@ -189,7 +189,7 @@ class SecurePersistentStore extends PersistentStore {
             byte[] encryptedDataBytes = Base64.decode(encryptedData, Base64.DEFAULT);
             byte[] secretKey = rsaDecrypt(encryptedKeyBytes);
 
-            Cipher c = Cipher.getInstance(AES_MODE, "BC");
+            Cipher c = Cipher.getInstance(AES_MODE);
             c.init(Cipher.DECRYPT_MODE, new SecretKeySpec(secretKey, "AES"));
             byte[] decodedBytes = c.doFinal(encryptedDataBytes);
             return new String(decodedBytes, "UTF-8");
@@ -212,7 +212,7 @@ class SecurePersistentStore extends PersistentStore {
             byte[] encryptedKeyBytes = rsaEncrypt(secretKey);
             String encryptedKey = Base64.encodeToString(encryptedKeyBytes, Base64.DEFAULT);
 
-            Cipher c = Cipher.getInstance(AES_MODE, "BC");
+            Cipher c = Cipher.getInstance(AES_MODE);
             c.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(secretKey, "AES"));
             byte[] encodedBytes = c.doFinal(textToEncrypt.getBytes("UTF-8"));
             String encryptedBase64Encoded = Base64.encodeToString(encodedBytes, Base64.DEFAULT);

--- a/skygear/src/main/java/io/skygear/skygear/SecurePersistentStore.java
+++ b/skygear/src/main/java/io/skygear/skygear/SecurePersistentStore.java
@@ -1,0 +1,226 @@
+package io.skygear.skygear;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.Build;
+import android.security.keystore.KeyGenParameterSpec;
+import android.security.keystore.KeyProperties;
+import android.util.Base64;
+import android.util.Log;
+
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.UnrecoverableEntryException;
+import java.security.cert.CertificateException;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.KeyGenerator;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+
+/**
+ * The Skygear secure persistent store.
+ *
+ * This class manages persistent data of Skygear, it will encrypt current user data and access token
+ * before storing to SharedPreferences
+ */
+class SecurePersistentStore extends PersistentStore {
+    private static final String TAG = "Skygear SDK";
+
+    static final String ACCESS_TOKEN_KEY_ALIAS = "SkygearAccessTokenKey";
+    static final String CURRENT_USER_KEY_ALIAS = "SkygearCurrentUserKey";
+
+    static final String CURRENT_USER_ENCRYPTED_KEY = "current_user_encrypted";
+    static final String ACCESS_TOKEN_ENCRYPTED_KEY = "access_token_encrypted";
+    static final String CURRENT_USER_IV_KEY = "current_user_iv";
+    static final String ACCESS_TOKEN_IV_KEY = "access_token_iv";
+
+    private static final String TRANSFORMATION = "AES/GCM/NoPadding";
+    private static final String ANDROID_KEY_STORE = "AndroidKeyStore";
+
+    Encryptor encryptor;
+    Decryptor decryptor;
+
+    public SecurePersistentStore(Context context) {
+        super(context);
+    }
+
+    @Override
+    void restoreAuthUser(SharedPreferences pref) {
+        String encryptedCurrentUser = pref.getString(CURRENT_USER_ENCRYPTED_KEY, null);
+        String encodedIV = pref.getString(CURRENT_USER_IV_KEY, null);
+
+        if (encryptedCurrentUser == null || encodedIV == null) {
+            this.currentUser = null;
+            return;
+        }
+
+        try {
+            byte[] encryptedData = base64DecodeToByte(encryptedCurrentUser);
+            byte[] iv = base64DecodeToByte(encodedIV);
+            String currentUserString = getDecryptor().decryptData(CURRENT_USER_KEY_ALIAS, encryptedData, iv);
+            this.currentUser = RecordSerializer.deserialize(
+                    new JSONObject(currentUserString)
+            );
+        } catch (Exception e) {
+            Log.w(TAG, "Fail to decrypt saved current user object", e);
+            this.currentUser = null;
+        }
+    }
+
+    @Override
+    void saveAuthUser(SharedPreferences.Editor prefEditor) {
+        if (this.currentUser != null) {
+            String currentUserString = RecordSerializer.serialize(this.currentUser).toString();
+            try {
+                EncryptedResult r = getEncryptor().encryptText(CURRENT_USER_KEY_ALIAS, currentUserString);
+                String encryptedCurrentUser = base64EncodeToString(r.encryptedData);
+                String encodedIV = base64EncodeToString(r.initializationVector);
+                prefEditor.putString(CURRENT_USER_ENCRYPTED_KEY, encryptedCurrentUser);
+                prefEditor.putString(CURRENT_USER_IV_KEY, encodedIV);
+            } catch (Exception e) {
+                Log.w(TAG, "Fail to encrypt and save current user object", e);
+            }
+        } else {
+            prefEditor.remove(CURRENT_USER_ENCRYPTED_KEY);
+            prefEditor.remove(CURRENT_USER_IV_KEY);
+        }
+    }
+
+    @Override
+    void restoreAccessToken(SharedPreferences pref) {
+        String encryptedAccessToken = pref.getString(ACCESS_TOKEN_ENCRYPTED_KEY, null);
+        String encodedIV = pref.getString(ACCESS_TOKEN_IV_KEY, null);
+
+        if (encryptedAccessToken == null || encodedIV == null) {
+            this.accessToken = null;
+            return;
+        }
+
+        try {
+            byte[] encryptedData = base64DecodeToByte(encryptedAccessToken);
+            byte[] iv = base64DecodeToByte(encodedIV);
+            this.accessToken = getDecryptor().decryptData(ACCESS_TOKEN_KEY_ALIAS, encryptedData, iv);
+        } catch (Exception e) {
+            Log.w(TAG, "Fail to decrypt saved access token", e);
+            this.accessToken = null;
+        }
+    }
+
+    @Override
+    void saveAccessToken(SharedPreferences.Editor prefEditor) {
+        if (this.accessToken != null) {
+            try {
+                EncryptedResult r = getEncryptor().encryptText(ACCESS_TOKEN_KEY_ALIAS, this.accessToken);
+                String ecryptedAccessToken = base64EncodeToString(r.encryptedData);
+                String encodedIV = base64EncodeToString(r.initializationVector);
+                prefEditor.putString(ACCESS_TOKEN_ENCRYPTED_KEY, ecryptedAccessToken);
+                prefEditor.putString(ACCESS_TOKEN_IV_KEY, encodedIV);
+            } catch (Exception e) {
+                Log.w(TAG, "Fail to encrypt and save access token", e);
+            }
+        } else {
+            prefEditor.remove(ACCESS_TOKEN_ENCRYPTED_KEY);
+            prefEditor.remove(ACCESS_TOKEN_IV_KEY);
+        }
+    }
+
+    protected String base64EncodeToString(byte[] b) {
+        return Base64.encodeToString(b, Base64.DEFAULT);
+    }
+
+    protected byte[] base64DecodeToByte(String s) {
+        return Base64.decode(s, Base64.DEFAULT);
+    }
+
+    protected Encryptor getEncryptor() {
+        if (encryptor == null) {
+            encryptor = new Encryptor();
+        }
+        return encryptor;
+    }
+
+    protected Decryptor getDecryptor() {
+        if (decryptor == null) {
+            decryptor = new Decryptor();
+        }
+        return decryptor;
+    }
+
+    class Decryptor {
+
+        private KeyStore keyStore;
+
+        String decryptData(final String alias, final byte[] encrypted, final byte[] iv) throws NoSuchPaddingException,
+                NoSuchAlgorithmException, UnrecoverableEntryException, KeyStoreException, InvalidAlgorithmParameterException,
+                InvalidKeyException, BadPaddingException, IllegalBlockSizeException, IOException, CertificateException {
+            final Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+            final GCMParameterSpec spec = new GCMParameterSpec(128, iv);
+            cipher.init(Cipher.DECRYPT_MODE, getSecretKey(alias), spec);
+            return new String(cipher.doFinal(encrypted), "UTF-8");
+        }
+
+        private SecretKey getSecretKey(final String alias) throws UnrecoverableEntryException,
+                NoSuchAlgorithmException, KeyStoreException, IOException, CertificateException {
+            if (keyStore == null) {
+                keyStore = KeyStore.getInstance(ANDROID_KEY_STORE);
+                keyStore.load(null);
+            }
+            return ((KeyStore.SecretKeyEntry) keyStore.getEntry(alias, null)).getSecretKey();
+        }
+    }
+
+    class Encryptor {
+
+        EncryptedResult encryptText(final String alias, final String textToEncrypt) throws NoSuchPaddingException,
+                NoSuchAlgorithmException, NoSuchProviderException, InvalidAlgorithmParameterException,
+                InvalidKeyException, BadPaddingException, IllegalBlockSizeException, UnsupportedEncodingException {
+
+            final Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+            cipher.init(Cipher.ENCRYPT_MODE, getSecretKey(alias));
+            byte[] iv = cipher.getIV();
+
+            return new EncryptedResult(cipher.doFinal(textToEncrypt.getBytes("UTF-8")), iv);
+        }
+
+        private SecretKey getSecretKey(final String alias) throws NoSuchAlgorithmException,
+                NoSuchProviderException, InvalidAlgorithmParameterException {
+            KeyGenerator keyGenerator;
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEY_STORE);
+                keyGenerator.init(new KeyGenParameterSpec.Builder(
+                        alias, KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT)
+                        .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                        .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                        .build());
+            } else {
+                keyGenerator = KeyGenerator.getInstance(ANDROID_KEY_STORE);
+                // fixup init keyGenerator
+            }
+            return keyGenerator.generateKey();
+        }
+
+    }
+
+    class EncryptedResult {
+        byte[] encryptedData;
+        byte[] initializationVector;
+
+        EncryptedResult(byte[] data, byte[] iv) {
+            encryptedData = data;
+            initializationVector = iv;
+        }
+    }
+}

--- a/skygear/src/main/java/io/skygear/skygear/SecurePersistentStore.java
+++ b/skygear/src/main/java/io/skygear/skygear/SecurePersistentStore.java
@@ -138,7 +138,7 @@ class SecurePersistentStore extends PersistentStore {
 
     private Encryptor getEncryptor() {
         if (encryptor == null) {
-            encryptor = new Encryptor(this.context);
+            encryptor = new Encryptor();
         }
         return encryptor;
     }
@@ -198,12 +198,10 @@ class SecurePersistentStore extends PersistentStore {
 
     class Encryptor {
 
-        private final Context context;
         private KeyStore keyStore;
 
-        Encryptor(Context context) {
+        Encryptor() {
             super();
-            this.context = context;
         }
 
         EncryptedResult encryptText(final String textToEncrypt) throws NoSuchPaddingException,
@@ -266,7 +264,7 @@ class SecurePersistentStore extends PersistentStore {
             Calendar start = Calendar.getInstance();
             Calendar end = Calendar.getInstance();
             end.add(Calendar.YEAR, 1);
-            KeyPairGeneratorSpec spec = new KeyPairGeneratorSpec.Builder(this.context)
+            KeyPairGeneratorSpec spec = new KeyPairGeneratorSpec.Builder(context)
                     .setAlias(alias)
                     .setSerialNumber(BigInteger.ONE)
                     .setSubject(new X500Principal("CN=" + alias))
@@ -281,7 +279,7 @@ class SecurePersistentStore extends PersistentStore {
         }
     }
 
-    class EncryptedResult {
+    static class EncryptedResult {
         String encryptedKey;
         String encryptedData;
 

--- a/skygear/src/main/java/io/skygear/skygear/SecurePersistentStore.java
+++ b/skygear/src/main/java/io/skygear/skygear/SecurePersistentStore.java
@@ -3,31 +3,39 @@ package io.skygear.skygear;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Build;
-import android.security.keystore.KeyGenParameterSpec;
-import android.security.keystore.KeyProperties;
+import android.security.KeyPairGeneratorSpec;
 import android.util.Base64;
 import android.util.Log;
 
 import org.json.JSONObject;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
+import java.math.BigInteger;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
+import java.security.PublicKey;
+import java.security.SecureRandom;
 import java.security.UnrecoverableEntryException;
 import java.security.cert.CertificateException;
+import java.util.ArrayList;
+import java.util.Calendar;
 
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
+import javax.crypto.CipherInputStream;
+import javax.crypto.CipherOutputStream;
 import javax.crypto.IllegalBlockSizeException;
-import javax.crypto.KeyGenerator;
 import javax.crypto.NoSuchPaddingException;
-import javax.crypto.SecretKey;
-import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import javax.security.auth.x500.X500Principal;
 
 /**
  * The Skygear secure persistent store.
@@ -38,15 +46,15 @@ import javax.crypto.spec.GCMParameterSpec;
 class SecurePersistentStore extends PersistentStore {
     private static final String TAG = "Skygear SDK";
 
-    static final String ACCESS_TOKEN_KEY_ALIAS = "SkygearAccessTokenKey";
-    static final String CURRENT_USER_KEY_ALIAS = "SkygearCurrentUserKey";
+    static final String KEY_ALIAS = "SkygearKey";
 
     static final String CURRENT_USER_ENCRYPTED_KEY = "current_user_encrypted";
     static final String ACCESS_TOKEN_ENCRYPTED_KEY = "access_token_encrypted";
-    static final String CURRENT_USER_IV_KEY = "current_user_iv";
-    static final String ACCESS_TOKEN_IV_KEY = "access_token_iv";
+    static final String CURRENT_USER_ENCRYPTED_KEY_KEY = "current_user_encrypted_key";
+    static final String ACCESS_TOKEN_ENCRYPTED_KEY_KEY = "access_token_encrypted_key";
 
-    private static final String TRANSFORMATION = "AES/GCM/NoPadding";
+    private static final String RSA_MODE =  "RSA/ECB/PKCS1Padding";
+    private static final String AES_MODE = "AES/ECB/PKCS7Padding";
     private static final String ANDROID_KEY_STORE = "AndroidKeyStore";
 
     Encryptor encryptor;
@@ -59,17 +67,15 @@ class SecurePersistentStore extends PersistentStore {
     @Override
     void restoreAuthUser(SharedPreferences pref) {
         String encryptedCurrentUser = pref.getString(CURRENT_USER_ENCRYPTED_KEY, null);
-        String encodedIV = pref.getString(CURRENT_USER_IV_KEY, null);
+        String encryptedKey = pref.getString(CURRENT_USER_ENCRYPTED_KEY_KEY, null);
 
-        if (encryptedCurrentUser == null || encodedIV == null) {
+        if (encryptedCurrentUser == null || encryptedKey == null) {
             this.currentUser = null;
             return;
         }
 
         try {
-            byte[] encryptedData = base64DecodeToByte(encryptedCurrentUser);
-            byte[] iv = base64DecodeToByte(encodedIV);
-            String currentUserString = getDecryptor().decryptData(CURRENT_USER_KEY_ALIAS, encryptedData, iv);
+            String currentUserString = getDecryptor().decryptData(encryptedKey, encryptedCurrentUser);
             this.currentUser = RecordSerializer.deserialize(
                     new JSONObject(currentUserString)
             );
@@ -84,34 +90,30 @@ class SecurePersistentStore extends PersistentStore {
         if (this.currentUser != null) {
             String currentUserString = RecordSerializer.serialize(this.currentUser).toString();
             try {
-                EncryptedResult r = getEncryptor().encryptText(CURRENT_USER_KEY_ALIAS, currentUserString);
-                String encryptedCurrentUser = base64EncodeToString(r.encryptedData);
-                String encodedIV = base64EncodeToString(r.initializationVector);
-                prefEditor.putString(CURRENT_USER_ENCRYPTED_KEY, encryptedCurrentUser);
-                prefEditor.putString(CURRENT_USER_IV_KEY, encodedIV);
+                EncryptedResult r = getEncryptor().encryptText(currentUserString);
+                prefEditor.putString(CURRENT_USER_ENCRYPTED_KEY, r.encryptedData);
+                prefEditor.putString(CURRENT_USER_ENCRYPTED_KEY_KEY, r.encryptedKey);
             } catch (Exception e) {
                 Log.w(TAG, "Fail to encrypt and save current user object", e);
             }
         } else {
             prefEditor.remove(CURRENT_USER_ENCRYPTED_KEY);
-            prefEditor.remove(CURRENT_USER_IV_KEY);
+            prefEditor.remove(CURRENT_USER_ENCRYPTED_KEY_KEY);
         }
     }
 
     @Override
     void restoreAccessToken(SharedPreferences pref) {
         String encryptedAccessToken = pref.getString(ACCESS_TOKEN_ENCRYPTED_KEY, null);
-        String encodedIV = pref.getString(ACCESS_TOKEN_IV_KEY, null);
+        String encryptedKey = pref.getString(ACCESS_TOKEN_ENCRYPTED_KEY_KEY, null);
 
-        if (encryptedAccessToken == null || encodedIV == null) {
+        if (encryptedAccessToken == null || encryptedKey == null) {
             this.accessToken = null;
             return;
         }
 
         try {
-            byte[] encryptedData = base64DecodeToByte(encryptedAccessToken);
-            byte[] iv = base64DecodeToByte(encodedIV);
-            this.accessToken = getDecryptor().decryptData(ACCESS_TOKEN_KEY_ALIAS, encryptedData, iv);
+            this.accessToken = getDecryptor().decryptData(encryptedKey, encryptedAccessToken);
         } catch (Exception e) {
             Log.w(TAG, "Fail to decrypt saved access token", e);
             this.accessToken = null;
@@ -122,105 +124,179 @@ class SecurePersistentStore extends PersistentStore {
     void saveAccessToken(SharedPreferences.Editor prefEditor) {
         if (this.accessToken != null) {
             try {
-                EncryptedResult r = getEncryptor().encryptText(ACCESS_TOKEN_KEY_ALIAS, this.accessToken);
-                String ecryptedAccessToken = base64EncodeToString(r.encryptedData);
-                String encodedIV = base64EncodeToString(r.initializationVector);
-                prefEditor.putString(ACCESS_TOKEN_ENCRYPTED_KEY, ecryptedAccessToken);
-                prefEditor.putString(ACCESS_TOKEN_IV_KEY, encodedIV);
+                EncryptedResult r = getEncryptor().encryptText(this.accessToken);
+                prefEditor.putString(ACCESS_TOKEN_ENCRYPTED_KEY, r.encryptedData);
+                prefEditor.putString(ACCESS_TOKEN_ENCRYPTED_KEY_KEY, r.encryptedKey);
             } catch (Exception e) {
                 Log.w(TAG, "Fail to encrypt and save access token", e);
             }
         } else {
             prefEditor.remove(ACCESS_TOKEN_ENCRYPTED_KEY);
-            prefEditor.remove(ACCESS_TOKEN_IV_KEY);
+            prefEditor.remove(ACCESS_TOKEN_ENCRYPTED_KEY_KEY);
         }
     }
 
-    protected String base64EncodeToString(byte[] b) {
-        return Base64.encodeToString(b, Base64.DEFAULT);
-    }
-
-    protected byte[] base64DecodeToByte(String s) {
-        return Base64.decode(s, Base64.DEFAULT);
-    }
-
-    protected Encryptor getEncryptor() {
+    private Encryptor getEncryptor() {
         if (encryptor == null) {
-            encryptor = new Encryptor();
+            encryptor = new Encryptor(this.context);
         }
         return encryptor;
     }
 
-    protected Decryptor getDecryptor() {
+    private Decryptor getDecryptor() {
         if (decryptor == null) {
             decryptor = new Decryptor();
         }
         return decryptor;
     }
 
+    private String getRSACipherProvider() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            return "AndroidOpenSSL";
+        } else {
+            return "AndroidKeyStoreBCWorkaround";
+        }
+    }
+
     class Decryptor {
 
         private KeyStore keyStore;
 
-        String decryptData(final String alias, final byte[] encrypted, final byte[] iv) throws NoSuchPaddingException,
-                NoSuchAlgorithmException, UnrecoverableEntryException, KeyStoreException, InvalidAlgorithmParameterException,
-                InvalidKeyException, BadPaddingException, IllegalBlockSizeException, IOException, CertificateException {
-            final Cipher cipher = Cipher.getInstance(TRANSFORMATION);
-            final GCMParameterSpec spec = new GCMParameterSpec(128, iv);
-            cipher.init(Cipher.DECRYPT_MODE, getSecretKey(alias), spec);
-            return new String(cipher.doFinal(encrypted), "UTF-8");
-        }
+        private byte[] rsaDecrypt(byte[] encrypted) throws KeyStoreException,
+                CertificateException, NoSuchAlgorithmException, IOException, NoSuchProviderException,
+                NoSuchPaddingException, InvalidKeyException, UnrecoverableEntryException {
 
-        private SecretKey getSecretKey(final String alias) throws UnrecoverableEntryException,
-                NoSuchAlgorithmException, KeyStoreException, IOException, CertificateException {
             if (keyStore == null) {
                 keyStore = KeyStore.getInstance(ANDROID_KEY_STORE);
                 keyStore.load(null);
             }
-            return ((KeyStore.SecretKeyEntry) keyStore.getEntry(alias, null)).getSecretKey();
+            KeyStore.PrivateKeyEntry privateKeyEntry = (KeyStore.PrivateKeyEntry)keyStore.getEntry(
+                    KEY_ALIAS, null);
+            Cipher output = Cipher.getInstance(RSA_MODE, getRSACipherProvider());
+            output.init(Cipher.DECRYPT_MODE, privateKeyEntry.getPrivateKey());
+            CipherInputStream cipherInputStream = new CipherInputStream(
+                    new ByteArrayInputStream(encrypted), output);
+            ArrayList<Byte> values = new ArrayList<>();
+            int nextByte;
+            while ((nextByte = cipherInputStream.read()) != -1) {
+                values.add((byte)nextByte);
+            }
+
+            byte[] bytes = new byte[values.size()];
+            for(int i = 0; i < bytes.length; i++) {
+                bytes[i] = values.get(i).byteValue();
+            }
+            return bytes;
+        }
+
+        String decryptData(final String encryptedKey, final String encryptedData) throws NoSuchPaddingException,
+                NoSuchAlgorithmException, UnrecoverableEntryException, KeyStoreException,
+                InvalidKeyException, IOException, CertificateException, NoSuchProviderException,
+                BadPaddingException, IllegalBlockSizeException {
+            byte[] encryptedKeyBytes = Base64.decode(encryptedKey, Base64.DEFAULT);
+            byte[] encryptedDataBytes = Base64.decode(encryptedData, Base64.DEFAULT);
+            byte[] secretKey = rsaDecrypt(encryptedKeyBytes);
+
+            Cipher c = Cipher.getInstance(AES_MODE, "BC");
+            c.init(Cipher.DECRYPT_MODE, new SecretKeySpec(secretKey, "AES"));
+            byte[] decodedBytes = c.doFinal(encryptedDataBytes);
+            return new String(decodedBytes, "UTF-8");
         }
     }
 
     class Encryptor {
 
-        EncryptedResult encryptText(final String alias, final String textToEncrypt) throws NoSuchPaddingException,
-                NoSuchAlgorithmException, NoSuchProviderException, InvalidAlgorithmParameterException,
-                InvalidKeyException, BadPaddingException, IllegalBlockSizeException, UnsupportedEncodingException {
+        private final Context context;
+        private KeyStore keyStore;
 
-            final Cipher cipher = Cipher.getInstance(TRANSFORMATION);
-            cipher.init(Cipher.ENCRYPT_MODE, getSecretKey(alias));
-            byte[] iv = cipher.getIV();
-
-            return new EncryptedResult(cipher.doFinal(textToEncrypt.getBytes("UTF-8")), iv);
+        Encryptor(Context context) {
+            super();
+            this.context = context;
         }
 
-        private SecretKey getSecretKey(final String alias) throws NoSuchAlgorithmException,
-                NoSuchProviderException, InvalidAlgorithmParameterException {
-            KeyGenerator keyGenerator;
+        EncryptedResult encryptText(final String textToEncrypt) throws NoSuchPaddingException,
+                NoSuchAlgorithmException, NoSuchProviderException, InvalidKeyException, IOException,
+                BadPaddingException, IllegalBlockSizeException, CertificateException, KeyStoreException,
+                UnrecoverableEntryException, InvalidAlgorithmParameterException {
+            byte[] secretKey = generateAESSecret();
+            byte[] encryptedKeyBytes = rsaEncrypt(secretKey);
+            String encryptedKey = Base64.encodeToString(encryptedKeyBytes, Base64.DEFAULT);
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEY_STORE);
-                keyGenerator.init(new KeyGenParameterSpec.Builder(
-                        alias, KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT)
-                        .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
-                        .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
-                        .build());
-            } else {
-                keyGenerator = KeyGenerator.getInstance(ANDROID_KEY_STORE);
-                // fixup init keyGenerator
+            Cipher c = Cipher.getInstance(AES_MODE, "BC");
+            c.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(secretKey, "AES"));
+            byte[] encodedBytes = c.doFinal(textToEncrypt.getBytes("UTF-8"));
+            String encryptedBase64Encoded = Base64.encodeToString(encodedBytes, Base64.DEFAULT);
+            return new EncryptedResult(encryptedKey, encryptedBase64Encoded);
+        }
+
+        private byte[] generateAESSecret() {
+            byte[] key = new byte[16];
+            SecureRandom secureRandom = new SecureRandom();
+            secureRandom.nextBytes(key);
+            return key;
+        }
+
+        private byte[] rsaEncrypt(byte[] secret) throws NoSuchAlgorithmException,
+                IOException, NoSuchProviderException, NoSuchPaddingException,
+                InvalidKeyException, InvalidAlgorithmParameterException, CertificateException,
+                KeyStoreException, UnrecoverableEntryException {
+            PublicKey publicKey = getRSAPublicKey();
+            Cipher inputCipher = Cipher.getInstance(RSA_MODE, getRSACipherProvider());
+            inputCipher.init(Cipher.ENCRYPT_MODE, publicKey);
+
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            CipherOutputStream cipherOutputStream = new CipherOutputStream(outputStream, inputCipher);
+            cipherOutputStream.write(secret);
+            cipherOutputStream.close();
+
+            byte[] vals = outputStream.toByteArray();
+            return vals;
+        }
+
+        private PublicKey getRSAPublicKey() throws NoSuchAlgorithmException,
+                NoSuchProviderException, InvalidAlgorithmParameterException, KeyStoreException,
+                IOException, CertificateException, UnrecoverableEntryException {
+            if (keyStore == null) {
+                keyStore = KeyStore.getInstance(ANDROID_KEY_STORE);
+                keyStore.load(null);
             }
-            return keyGenerator.generateKey();
+
+            if (!keyStore.containsAlias(KEY_ALIAS)) {
+                return generateRSAPublicKey(KEY_ALIAS);
+            }
+
+            return ((KeyStore.PrivateKeyEntry) keyStore.getEntry(KEY_ALIAS, null))
+                    .getCertificate().getPublicKey();
         }
 
+        private PublicKey generateRSAPublicKey(final String alias) throws NoSuchAlgorithmException,
+                NoSuchProviderException, InvalidAlgorithmParameterException {
+            Calendar start = Calendar.getInstance();
+            Calendar end = Calendar.getInstance();
+            end.add(Calendar.YEAR, 1);
+            KeyPairGeneratorSpec spec = new KeyPairGeneratorSpec.Builder(this.context)
+                    .setAlias(alias)
+                    .setSerialNumber(BigInteger.ONE)
+                    .setSubject(new X500Principal("CN=" + alias))
+                    .setStartDate(start.getTime())
+                    .setEndDate(end.getTime())
+                    .build();
+            KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA", ANDROID_KEY_STORE);
+            generator.initialize(spec);
+
+            KeyPair keyPair = generator.generateKeyPair();
+            return keyPair.getPublic();
+        }
     }
 
     class EncryptedResult {
-        byte[] encryptedData;
-        byte[] initializationVector;
+        String encryptedKey;
+        String encryptedData;
 
-        EncryptedResult(byte[] data, byte[] iv) {
-            encryptedData = data;
-            initializationVector = iv;
+        EncryptedResult(String encryptedKey, String encryptedData) {
+            super();
+            this.encryptedKey = encryptedKey;
+            this.encryptedData = encryptedData;
         }
     }
 }

--- a/skygear/src/main/java/io/skygear/skygear/SkygearApplication.java
+++ b/skygear/src/main/java/io/skygear/skygear/SkygearApplication.java
@@ -55,6 +55,16 @@ public abstract class SkygearApplication extends Application {
         return false;
     }
 
+
+    /**
+     * Gets whether encrypt current user data saved in SharedPreferences.
+     *
+     * @return the boolean indicating whether encrypt current user data saved in SharedPreferences
+     */
+    public boolean encryptCurrentUserData() {
+        return false;
+    }
+
     @Override
     public void onCreate() {
         super.onCreate();
@@ -64,6 +74,7 @@ public abstract class SkygearApplication extends Application {
                 .apiKey(this.getApiKey())
                 .gcmSenderId(this.getGcmSenderId())
                 .pubsubHandlerExecutionInBackground(this.isPubsubHandlerExecutionInBackground())
+                .encryptCurrentUserData(this.encryptCurrentUserData())
                 .build();
 
         Container.defaultContainer(this).configure(config);

--- a/skygear_example/build.gradle
+++ b/skygear_example/build.gradle
@@ -36,7 +36,7 @@ android {
 
     defaultConfig {
         applicationId "io.skygear.skygear_example"
-        minSdkVersion 16
+        minSdkVersion 18
         targetSdkVersion 26
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
connect SkygearIO/features#250

This is configurable, the default is OFF.

Flow:
- Generate a pair of RSA keys and store in keystore
- Generate a random AES key
- Encrypt the AES key using the RSA key
- Use AES secrets key to encrypt the current user data
- Store encrypted AES Key and encrypted current user data to SharedPreferences