### PR TITLE
Fix fail to call lambda without arguments

### DIFF
--- a/skygear/src/main/java/io/skygear/skygear/Container.java
+++ b/skygear/src/main/java/io/skygear/skygear/Container.java
@@ -234,7 +234,7 @@ public final class Container {
 
             @Override
             public void onFailure(Error error) {
-
+                responseHandler.onFail(error);
             }
         });
     }
@@ -265,7 +265,7 @@ public final class Container {
 
             @Override
             public void onFailure(Error error) {
-
+                responseHandler.onFail(error);
             }
         });
     }

--- a/skygear/src/main/java/io/skygear/skygear/Container.java
+++ b/skygear/src/main/java/io/skygear/skygear/Container.java
@@ -203,7 +203,9 @@ public final class Container {
      * @param handler the response handler
      */
     public void callLambdaFunction(String name, LambdaResponseHandler handler) {
-        this.callLambdaFunction(name, (Object[]) null, handler);
+        LambdaRequest request = new LambdaRequest(name, (Object)null);
+        request.responseHandler = handler;
+        this.requestManager.sendRequest(request);
     }
 
     /**

--- a/skygear/src/main/java/io/skygear/skygear/Container.java
+++ b/skygear/src/main/java/io/skygear/skygear/Container.java
@@ -216,6 +216,10 @@ public final class Container {
      * @param handler the response handler
      */
     public void callLambdaFunction(final String name, Object[] args, LambdaResponseHandler handler) {
+        if (args == null) {
+            this.callLambdaFunction(name, handler);
+            return;
+        }
         final String lambdaName = name;
         final Object[] lambdaArgs = args;
         final LambdaResponseHandler responseHandler = handler;
@@ -243,6 +247,10 @@ public final class Container {
      * @param handler the response handler
      */
     public void callLambdaFunction(String name, Map<String, Object> args, LambdaResponseHandler handler) {
+        if (args == null) {
+            this.callLambdaFunction(name, handler);
+            return;
+        }
         final String lambdaName = name;
         final Map<String, Object> lambdaArgs = args;
         final LambdaResponseHandler responseHandler = handler;


### PR DESCRIPTION
connects #276

This bug occurs after adding auto upload asset when calling lambda, sdk will check the arguments if there is any not updated assets.
Update the callLambdaFunction implementation to skip the presave.